### PR TITLE
Update face_feature_mask.cpp

### DIFF
--- a/facialrecognitionapp/face_feature_mask/face_feature_mask.cpp
+++ b/facialrecognitionapp/face_feature_mask/face_feature_mask.cpp
@@ -161,8 +161,8 @@ bool FaceFeatureMaskProcess::Crop(const shared_ptr<FaceRecognitionInfo> &face_re
     u_int32_t lt_vert = ((face_img_iter->rectangle.lt.y) >> 1) << 1;
 
     // Change the left top coordinate to odd numver
-    u_int32_t rb_horz = (((face_img_iter->rectangle.rb.x) >> 1) << 1) + 1;
-    u_int32_t rb_vert = (((face_img_iter->rectangle.rb.y) >> 1) << 1) + 1;
+    u_int32_t rb_horz = (((face_img_iter->rectangle.rb.x) >> 1) << 1) - 1;
+    u_int32_t rb_vert = (((face_img_iter->rectangle.rb.y) >> 1) << 1) - 1;
     HIAI_ENGINE_LOG("The crop is from left-top(%d,%d) to right-bottom(%d,%d)",
                     lt_horz, lt_vert, rb_horz, rb_vert);
     u_int32_t cropped_width = rb_horz - lt_horz + 1;


### PR DESCRIPTION
DTS2019062613235
【Atlas200DK/sample运行】在海思发布的A200DK的sample-facialrecognition中，进行登记图片操作时，出现DVPP抠图错误现象，影响程序运行。